### PR TITLE
Fix: handle proto type instead of schema on Lineage API

### DIFF
--- a/core/schema/lineage.go
+++ b/core/schema/lineage.go
@@ -234,11 +234,3 @@ func computeLineage(data []byte, namespaceID, schemaID, rootType string, level i
 
 	return resp, nil
 }
-
-// lastSegment returns the last dot-separated segment of a fully-qualified name.
-func lastSegment(fqn string) string {
-	if idx := strings.LastIndex(fqn, "."); idx >= 0 {
-		return fqn[idx+1:]
-	}
-	return fqn
-}

--- a/core/schema/lineage.go
+++ b/core/schema/lineage.go
@@ -20,13 +20,15 @@ const (
 // RootSchemaRef identifies the schema on which lineage is requested.
 type RootSchemaRef struct {
 	NamespaceID string `json:"namespace_id"`
-	SchemaName  string `json:"schema_name"`
+	SchemaID    string `json:"schema_id"`
+	TypeName    string `json:"type_name"`
 }
 
 // LineageSchema represents a single schema in the lineage graph.
 type LineageSchema struct {
 	NamespaceID string   `json:"namespace_id"`
-	SchemaName  string   `json:"schema_name"`
+	SchemaID    string   `json:"schema_id"`
+	TypeName    string   `json:"type_name"`
 	Level       int      `json:"level"`
 	Path        []string `json:"path"`
 }
@@ -156,18 +158,17 @@ type bfsNode struct {
 	path  []string
 }
 
-func convertLineageNodes(namespaceID string, nodes []bfsNode) []LineageSchema {
+func convertLineageNodes(namespaceID, schemaID string, nodes []bfsNode) []LineageSchema {
 	lineage := make([]LineageSchema, 0, len(nodes))
 	for _, node := range nodes {
-		shortPath := make([]string, len(node.path))
-		for i, p := range node.path {
-			shortPath[i] = lastSegment(p)
-		}
+		fullPath := make([]string, len(node.path))
+		copy(fullPath, node.path)
 		lineage = append(lineage, LineageSchema{
 			NamespaceID: namespaceID,
-			SchemaName:  lastSegment(node.fqn),
+			SchemaID:    schemaID,
+			TypeName:    node.fqn,
 			Level:       node.level,
-			Path:        shortPath,
+			Path:        fullPath,
 		})
 	}
 	return lineage
@@ -175,7 +176,7 @@ func convertLineageNodes(namespaceID string, nodes []bfsNode) []LineageSchema {
 
 // computeLineage is the core logic: given raw schema bytes, a root schema name,
 // level limit, and traversal direction, it returns a LineageResponse.
-func computeLineage(data []byte, namespaceID, schemaName string, level int, direction LineageDirection) (*LineageResponse, error) {
+func computeLineage(data []byte, namespaceID, schemaID, rootType string, level int, direction LineageDirection) (*LineageResponse, error) {
 	fds, err := changedetector.GetDescriptorSet(data)
 	if err != nil {
 		return nil, err
@@ -186,12 +187,13 @@ func computeLineage(data []byte, namespaceID, schemaName string, level int, dire
 	}
 
 	forwardDeps, reverseDeps := buildDependencyMaps(fds)
-	roots := findRootFQNs(fds, schemaName)
+	roots := findRootFQNs(fds, rootType)
 
 	resp := &LineageResponse{
 		RootSchema: RootSchemaRef{
 			NamespaceID: namespaceID,
-			SchemaName:  schemaName,
+			SchemaID:    schemaID,
+			TypeName:    rootType,
 		},
 		Direction: direction,
 	}
@@ -209,7 +211,7 @@ func computeLineage(data []byte, namespaceID, schemaName string, level int, dire
 				downstreamSeen[node.fqn] = true
 				filtered = append(filtered, node)
 			}
-			resp.Downstream = append(resp.Downstream, convertLineageNodes(namespaceID, filtered)...)
+			resp.Downstream = append(resp.Downstream, convertLineageNodes(namespaceID, schemaID, filtered)...)
 		}
 
 		if direction == LineageDirectionBoth || direction == LineageDirectionUpstream {
@@ -222,7 +224,7 @@ func computeLineage(data []byte, namespaceID, schemaName string, level int, dire
 				upstreamSeen[node.fqn] = true
 				filtered = append(filtered, node)
 			}
-			resp.Upstream = append(resp.Upstream, convertLineageNodes(namespaceID, filtered)...)
+			resp.Upstream = append(resp.Upstream, convertLineageNodes(namespaceID, schemaID, filtered)...)
 		}
 	}
 

--- a/core/schema/lineage_test.go
+++ b/core/schema/lineage_test.go
@@ -106,7 +106,7 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("GetLatestVersion", mock.Anything, "ns1", "Root").Return(int32(0), errors.New("not found"))
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		_, err := svc.GetLineage(ctx, "ns1", "Root", 5, schema.LineageDirectionDownstream)
+		_, err := svc.GetLineage(ctx, "ns1", "Root", "Root", 5, schema.LineageDirectionDownstream)
 
 		assert.Error(t, err)
 	})
@@ -121,13 +121,14 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "Child", int32(1)).Return(data, nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		resp, err := svc.GetLineage(ctx, "ns1", "Child", 5, schema.LineageDirectionDownstream)
+		resp, err := svc.GetLineage(ctx, "ns1", "Child", "Child", 5, schema.LineageDirectionDownstream)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 		assert.Equal(t, schema.LineageDirectionDownstream, resp.Direction)
 		assert.Equal(t, "ns1", resp.RootSchema.NamespaceID)
-		assert.Equal(t, "Child", resp.RootSchema.SchemaName)
+		assert.Equal(t, "Child", resp.RootSchema.SchemaID)
+		assert.Equal(t, "Child", resp.RootSchema.TypeName)
 		assert.Empty(t, resp.Downstream)
 		assert.Empty(t, resp.Upstream)
 		assert.Equal(t, 0, resp.Summary.TotalCount)
@@ -143,16 +144,16 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "Root", int32(1)).Return(data, nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		resp, err := svc.GetLineage(ctx, "ns1", "Root", 5, schema.LineageDirectionDownstream)
+		resp, err := svc.GetLineage(ctx, "ns1", "Root", "Root", 5, schema.LineageDirectionDownstream)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
-		assert.Equal(t, "Root", resp.RootSchema.SchemaName)
+		assert.Equal(t, "Root", resp.RootSchema.TypeName)
 		assert.Equal(t, 1, resp.Summary.DownstreamCount)
 		assert.Equal(t, 1, resp.Summary.TotalCount)
-		assert.Equal(t, "Child", resp.Downstream[0].SchemaName)
+		assert.Equal(t, "mypackage.Child", resp.Downstream[0].TypeName)
 		assert.Equal(t, 1, resp.Downstream[0].Level)
-		assert.Equal(t, []string{"Root", "Child"}, resp.Downstream[0].Path)
+		assert.Equal(t, []string{"mypackage.Root", "mypackage.Child"}, resp.Downstream[0].Path)
 	})
 
 	t.Run("should return upstream lineage", func(t *testing.T) {
@@ -165,14 +166,14 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "GrandChild", int32(1)).Return(data, nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		resp, err := svc.GetLineage(ctx, "ns1", "GrandChild", 10, schema.LineageDirectionUpstream)
+		resp, err := svc.GetLineage(ctx, "ns1", "GrandChild", "GrandChild", 10, schema.LineageDirectionUpstream)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, resp.Summary.UpstreamCount)
 		assert.Equal(t, 2, resp.Summary.TotalCount)
-		assert.Equal(t, "Child", resp.Upstream[0].SchemaName)
-		assert.Equal(t, "Root", resp.Upstream[1].SchemaName)
-		assert.Equal(t, []string{"GrandChild", "Child"}, resp.Upstream[0].Path)
+		assert.Equal(t, "mypackage.Child", resp.Upstream[0].TypeName)
+		assert.Equal(t, "mypackage.Root", resp.Upstream[1].TypeName)
+		assert.Equal(t, []string{"mypackage.GrandChild", "mypackage.Child"}, resp.Upstream[0].Path)
 	})
 
 	t.Run("should default to both directions when direction is empty", func(t *testing.T) {
@@ -185,15 +186,15 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "Child", int32(1)).Return(data, nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		resp, err := svc.GetLineage(ctx, "ns1", "Child", 10, "")
+		resp, err := svc.GetLineage(ctx, "ns1", "Child", "Child", 10, "")
 
 		assert.NoError(t, err)
 		assert.Equal(t, schema.LineageDirectionBoth, resp.Direction)
 		assert.Equal(t, 1, resp.Summary.DownstreamCount)
 		assert.Equal(t, 1, resp.Summary.UpstreamCount)
 		assert.Equal(t, 2, resp.Summary.TotalCount)
-		assert.Equal(t, "GrandChild", resp.Downstream[0].SchemaName)
-		assert.Equal(t, "Root", resp.Upstream[0].SchemaName)
+		assert.Equal(t, "mypackage.GrandChild", resp.Downstream[0].TypeName)
+		assert.Equal(t, "mypackage.Root", resp.Upstream[0].TypeName)
 	})
 
 	t.Run("should respect level=1 and not traverse deeper", func(t *testing.T) {
@@ -206,11 +207,11 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "Root", int32(1)).Return(data, nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		resp, err := svc.GetLineage(ctx, "ns1", "Root", 1, schema.LineageDirectionDownstream)
+		resp, err := svc.GetLineage(ctx, "ns1", "Root", "Root", 1, schema.LineageDirectionDownstream)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 1, resp.Summary.DownstreamCount)
-		assert.Equal(t, "Child", resp.Downstream[0].SchemaName)
+		assert.Equal(t, "mypackage.Child", resp.Downstream[0].TypeName)
 	})
 
 	t.Run("should traverse multi-level downstream lineage", func(t *testing.T) {
@@ -223,17 +224,17 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "Root", int32(1)).Return(data, nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		resp, err := svc.GetLineage(ctx, "ns1", "Root", 10, schema.LineageDirectionDownstream)
+		resp, err := svc.GetLineage(ctx, "ns1", "Root", "Root", 10, schema.LineageDirectionDownstream)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, resp.Summary.DownstreamCount)
 
 		names := map[string]bool{}
 		for _, is := range resp.Downstream {
-			names[is.SchemaName] = true
+			names[is.TypeName] = true
 		}
-		assert.True(t, names["Child"])
-		assert.True(t, names["GrandChild"])
+		assert.True(t, names["mypackage.Child"])
+		assert.True(t, names["mypackage.GrandChild"])
 	})
 
 	t.Run("should use default level=10 when 0 is passed", func(t *testing.T) {
@@ -246,7 +247,7 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "Root", int32(1)).Return(data, nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		resp, err := svc.GetLineage(ctx, "ns1", "Root", 0, schema.LineageDirectionDownstream) // 0 → default 10
+		resp, err := svc.GetLineage(ctx, "ns1", "Root", "Root", 0, schema.LineageDirectionDownstream) // 0 → default 10
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, resp.Summary.DownstreamCount)
@@ -260,7 +261,7 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "Root", int32(1)).Return([]byte("not valid proto"), nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		_, err := svc.GetLineage(ctx, "ns1", "Root", 5, schema.LineageDirectionDownstream)
+		_, err := svc.GetLineage(ctx, "ns1", "Root", "Root", 5, schema.LineageDirectionDownstream)
 
 		assert.Error(t, err)
 	})
@@ -274,7 +275,7 @@ func TestGetLineage(t *testing.T) {
 		schemaRepo.On("Get", mock.Anything, "ns1", "Root", int32(1)).Return(data, nil)
 		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
 
-		_, err := svc.GetLineage(ctx, "ns1", "Root", 5, schema.LineageDirection("sideways"))
+		_, err := svc.GetLineage(ctx, "ns1", "Root", "Root", 5, schema.LineageDirection("sideways"))
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid direction")
@@ -288,12 +289,12 @@ func TestGetLineage(t *testing.T) {
 func TestLineageStructs(t *testing.T) {
 	t.Run("LineageResponse summary counts", func(t *testing.T) {
 		resp := schema.LineageResponse{
-			RootSchema: schema.RootSchemaRef{NamespaceID: "ns", SchemaName: "Foo"},
+			RootSchema: schema.RootSchemaRef{NamespaceID: "ns", SchemaID: "sc", TypeName: "Foo"},
 			Downstream: []schema.LineageSchema{
-				{SchemaName: "Bar"},
+				{SchemaID: "sc", TypeName: "Bar"},
 			},
 			Upstream: []schema.LineageSchema{
-				{SchemaName: "Baz"},
+				{SchemaID: "sc", TypeName: "Baz"},
 			},
 			Summary: schema.LineageSummary{DownstreamCount: 1, UpstreamCount: 1, TotalCount: 2},
 		}

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -348,17 +348,18 @@ func (s *Service) DetectSchemaChange(namespace string, schemaName string, fromVe
 	return sce, nil
 }
 
-// GetLineage returns schema lineage in the namespace for the given schema.
+// GetLineage returns lineage in a schema container for the given root type.
+// schemaID identifies the stored schema artifact; rootType is the message to trace.
 // level limits traversal depth (0 or negative → default of 10).
-func (s *Service) GetLineage(ctx context.Context, namespaceID, schemaName string, level int, direction LineageDirection) (*LineageResponse, error) {
+func (s *Service) GetLineage(ctx context.Context, namespaceID, schemaID, rootType string, level int, direction LineageDirection) (*LineageResponse, error) {
 	if level <= 0 {
 		level = 10
 	}
-	_, data, err := s.GetLatest(ctx, namespaceID, schemaName)
+	_, data, err := s.GetLatest(ctx, namespaceID, schemaID)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching latest schema for %s/%s: %w", namespaceID, schemaName, err)
+		return nil, fmt.Errorf("error fetching latest schema for %s/%s: %w", namespaceID, schemaID, err)
 	}
-	return computeLineage(data, namespaceID, schemaName, level, direction)
+	return computeLineage(data, namespaceID, schemaID, rootType, level, direction)
 }
 
 func (s *Service) ValidateVersions(ctx context.Context, namespace string, schemaName string, fromVersion string, toVersion string) (int32, int32, error) {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -41,7 +41,7 @@ type SchemaService interface {
 	List(ctx context.Context, namespaceID string) ([]schema.Schema, error)
 	ListVersions(ctx context.Context, namespaceID string, schemaName string) ([]int32, error)
 	DetectSchemaChange(namespace string, schemaName string, fromVersion string, toVersion string, depth string) (*stencilv1beta1.SchemaChangedEvent, error)
-	GetLineage(ctx context.Context, namespaceID, schemaName string, level int, direction schema.LineageDirection) (*schema.LineageResponse, error)
+	GetLineage(ctx context.Context, namespaceID, schemaID, rootType string, level int, direction schema.LineageDirection) (*schema.LineageResponse, error)
 }
 
 type SearchService interface {
@@ -76,7 +76,7 @@ func (a *API) RegisterSchemaHandlers(mux *runtime.ServeMux, app *newrelic.Applic
 	mux.HandlePath(wrapHandler(app, "POST", "/v1beta1/namespaces/{namespace}/schemas/{name}", wrapErrHandler(mux, a.HTTPUpload)))
 	mux.HandlePath(wrapHandler(app, "POST", "/v1beta1/namespaces/{namespace}/schemas/{name}/check", wrapErrHandler(mux, a.HTTPCheckCompatibility)))
 	mux.HandlePath(wrapHandler(app, "GET", "/v1beta1/schema/detect-change/{namespaceId}/{schemaName}", wrapErrHandler(mux, a.DetectSchemaChange)))
-	mux.HandlePath(wrapHandler(app, "GET", "/v1beta1/namespaces/{namespace_id}/schemas/{schema_name}/lineage", wrapErrHandler(mux, a.GetLineage)))
+	mux.HandlePath(wrapHandler(app, "GET", "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}/types/{type_name}/lineage", wrapErrHandler(mux, a.GetLineage)))
 }
 
 func handleSchemaResponse(mux *runtime.ServeMux, getSchemaFn getSchemaData) runtime.HandlerFunc {

--- a/internal/api/lineage_test.go
+++ b/internal/api/lineage_test.go
@@ -15,13 +15,14 @@ import (
 
 func TestGetLineageHandler(t *testing.T) {
 	nsName := "namespace1"
-	schemaName := "MySchema"
-	endpoint := fmt.Sprintf("/v1beta1/namespaces/%s/schemas/%s/lineage", nsName, schemaName)
+	schemaID := "esb-log-entities"
+	typeName := "gojek.esb.types.Location"
+	endpoint := fmt.Sprintf("/v1beta1/namespaces/%s/schemas/%s/types/%s/lineage", nsName, schemaID, typeName)
 
 	t.Run("should return 500 when service returns error", func(t *testing.T) {
 		_, schemaSvc, _, mux, _, _ := setup()
 
-		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaName, 10, schema.LineageDirectionBoth).
+		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaID, typeName, 10, schema.LineageDirectionBoth).
 			Return(nil, errors.New("service error"))
 
 		req, _ := http.NewRequest("GET", endpoint, nil)
@@ -40,15 +41,17 @@ func TestGetLineageHandler(t *testing.T) {
 		lineageResp := &schema.LineageResponse{
 			RootSchema: schema.RootSchemaRef{
 				NamespaceID: nsName,
-				SchemaName:  schemaName,
+				SchemaID:    schemaID,
+				TypeName:    typeName,
 			},
 			Direction: schema.LineageDirectionBoth,
 			Downstream: []schema.LineageSchema{
 				{
 					NamespaceID: nsName,
-					SchemaName:  "DependentSchema",
+					SchemaID:    schemaID,
+					TypeName:    "gojek.esb.types.DependentSchema",
 					Level:       1,
-					Path:        []string{schemaName, "DependentSchema"},
+					Path:        []string{"gojek.esb.types.Location", "gojek.esb.types.DependentSchema"},
 				},
 			},
 			Summary: schema.LineageSummary{
@@ -57,7 +60,7 @@ func TestGetLineageHandler(t *testing.T) {
 			},
 		}
 
-		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaName, 10, schema.LineageDirectionBoth).
+		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaID, typeName, 10, schema.LineageDirectionBoth).
 			Return(lineageResp, nil)
 
 		req, _ := http.NewRequest("GET", endpoint, nil)
@@ -67,7 +70,7 @@ func TestGetLineageHandler(t *testing.T) {
 		mux.ServeHTTP(w, req)
 
 		assert.Equal(t, 200, w.Code)
-		assert.Contains(t, w.Body.String(), "DependentSchema")
+		assert.Contains(t, w.Body.String(), "gojek.esb.types.DependentSchema")
 		schemaSvc.AssertExpectations(t)
 	})
 
@@ -75,12 +78,12 @@ func TestGetLineageHandler(t *testing.T) {
 		_, schemaSvc, _, mux, _, _ := setup()
 
 		lineageResp := &schema.LineageResponse{
-			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaName: schemaName},
+			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaID: schemaID, TypeName: typeName},
 			Direction:  schema.LineageDirectionBoth,
 			Summary:    schema.LineageSummary{},
 		}
 
-		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaName, 3, schema.LineageDirectionBoth).
+		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaID, typeName, 3, schema.LineageDirectionBoth).
 			Return(lineageResp, nil)
 
 		req, _ := http.NewRequest("GET", endpoint+"?level=3", nil)
@@ -97,12 +100,12 @@ func TestGetLineageHandler(t *testing.T) {
 		_, schemaSvc, _, mux, _, _ := setup()
 
 		lineageResp := &schema.LineageResponse{
-			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaName: schemaName},
+			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaID: schemaID, TypeName: typeName},
 			Direction:  schema.LineageDirectionBoth,
 			Summary:    schema.LineageSummary{},
 		}
 
-		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaName, 10, schema.LineageDirectionBoth).
+		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaID, typeName, 10, schema.LineageDirectionBoth).
 			Return(lineageResp, nil)
 
 		req, _ := http.NewRequest("GET", endpoint+"?level=invalid", nil)
@@ -119,12 +122,12 @@ func TestGetLineageHandler(t *testing.T) {
 		_, schemaSvc, _, mux, _, _ := setup()
 
 		lineageResp := &schema.LineageResponse{
-			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaName: schemaName},
+			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaID: schemaID, TypeName: typeName},
 			Direction:  schema.LineageDirectionBoth,
 			Summary:    schema.LineageSummary{},
 		}
 
-		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaName, 10, schema.LineageDirectionBoth).
+		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaID, typeName, 10, schema.LineageDirectionBoth).
 			Return(lineageResp, nil)
 
 		req, _ := http.NewRequest("GET", endpoint+"?level=0", nil)
@@ -141,12 +144,12 @@ func TestGetLineageHandler(t *testing.T) {
 		_, schemaSvc, _, mux, _, _ := setup()
 
 		lineageResp := &schema.LineageResponse{
-			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaName: schemaName},
+			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaID: schemaID, TypeName: typeName},
 			Direction:  schema.LineageDirectionDownstream,
 			Summary:    schema.LineageSummary{},
 		}
 
-		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaName, 10, schema.LineageDirectionDownstream).
+		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaID, typeName, 10, schema.LineageDirectionDownstream).
 			Return(lineageResp, nil)
 
 		req, _ := http.NewRequest("GET", endpoint+"?direction=downstream", nil)
@@ -163,12 +166,12 @@ func TestGetLineageHandler(t *testing.T) {
 		_, schemaSvc, _, mux, _, _ := setup()
 
 		lineageResp := &schema.LineageResponse{
-			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaName: schemaName},
+			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaID: schemaID, TypeName: typeName},
 			Direction:  schema.LineageDirectionUpstream,
 			Summary:    schema.LineageSummary{},
 		}
 
-		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaName, 10, schema.LineageDirectionUpstream).
+		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaID, typeName, 10, schema.LineageDirectionUpstream).
 			Return(lineageResp, nil)
 
 		req, _ := http.NewRequest("GET", endpoint+"?direction=upstream", nil)
@@ -192,5 +195,27 @@ func TestGetLineageHandler(t *testing.T) {
 
 		assert.Equal(t, 400, w.Code)
 		schemaSvc.AssertNotCalled(t, "GetLineage")
+	})
+
+	t.Run("should use type_name from path while schema path remains schema container", func(t *testing.T) {
+		_, schemaSvc, _, mux, _, _ := setup()
+
+		lineageResp := &schema.LineageResponse{
+			RootSchema: schema.RootSchemaRef{NamespaceID: nsName, SchemaID: schemaID, TypeName: typeName},
+			Direction:  schema.LineageDirectionDownstream,
+			Summary:    schema.LineageSummary{},
+		}
+
+		schemaSvc.On("GetLineage", mock.Anything, nsName, schemaID, typeName, 10, schema.LineageDirectionDownstream).
+			Return(lineageResp, nil)
+
+		req, _ := http.NewRequest("GET", endpoint+"?direction=downstream", nil)
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, 200, w.Code)
+		schemaSvc.AssertExpectations(t)
 	})
 }

--- a/internal/api/mocks/schema_service.go
+++ b/internal/api/mocks/schema_service.go
@@ -167,9 +167,9 @@ func (_m *SchemaService) Get(ctx context.Context, namespace string, schemaName s
 	return r0, r1, r2
 }
 
-// GetLineage provides a mock function with given fields: ctx, namespaceID, schemaName, level, direction
-func (_m *SchemaService) GetLineage(ctx context.Context, namespaceID string, schemaName string, level int, direction schema.LineageDirection) (*schema.LineageResponse, error) {
-	ret := _m.Called(ctx, namespaceID, schemaName, level, direction)
+// GetLineage provides a mock function with given fields: ctx, namespaceID, schemaID, rootType, level, direction
+func (_m *SchemaService) GetLineage(ctx context.Context, namespaceID string, schemaID string, rootType string, level int, direction schema.LineageDirection) (*schema.LineageResponse, error) {
+	ret := _m.Called(ctx, namespaceID, schemaID, rootType, level, direction)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLineage")
@@ -177,19 +177,19 @@ func (_m *SchemaService) GetLineage(ctx context.Context, namespaceID string, sch
 
 	var r0 *schema.LineageResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, schema.LineageDirection) (*schema.LineageResponse, error)); ok {
-		return rf(ctx, namespaceID, schemaName, level, direction)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, int, schema.LineageDirection) (*schema.LineageResponse, error)); ok {
+		return rf(ctx, namespaceID, schemaID, rootType, level, direction)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, schema.LineageDirection) *schema.LineageResponse); ok {
-		r0 = rf(ctx, namespaceID, schemaName, level, direction)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, int, schema.LineageDirection) *schema.LineageResponse); ok {
+		r0 = rf(ctx, namespaceID, schemaID, rootType, level, direction)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*schema.LineageResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, int, schema.LineageDirection) error); ok {
-		r1 = rf(ctx, namespaceID, schemaName, level, direction)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, int, schema.LineageDirection) error); ok {
+		r1 = rf(ctx, namespaceID, schemaID, rootType, level, direction)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -178,7 +178,11 @@ func (a *API) DeleteVersion(ctx context.Context, in *stencilv1beta1.DeleteVersio
 
 func (a *API) GetLineage(w http.ResponseWriter, req *http.Request, pathParams map[string]string) error {
 	namespaceID := pathParams["namespace_id"]
-	schemaName := pathParams["schema_name"]
+	schemaID := pathParams["schema_id"]
+	rootType := pathParams["type_name"]
+	if rootType == "" {
+		return &runtime.HTTPStatusError{HTTPStatus: http.StatusBadRequest, Err: errors.New("missing required path parameter: type_name")}
+	}
 
 	level := 10
 	if d := req.URL.Query().Get("level"); d != "" {
@@ -195,7 +199,7 @@ func (a *API) GetLineage(w http.ResponseWriter, req *http.Request, pathParams ma
 		return &runtime.HTTPStatusError{HTTPStatus: http.StatusBadRequest, Err: err}
 	}
 
-	resp, err := a.schema.GetLineage(req.Context(), namespaceID, schemaName, level, direction)
+	resp, err := a.schema.GetLineage(req.Context(), namespaceID, schemaID, rootType, level, direction)
 	if err != nil {
 		return err
 	}

--- a/proto/gotocompany/apidocs.swagger.json
+++ b/proto/gotocompany/apidocs.swagger.json
@@ -422,7 +422,7 @@
         ]
       }
     },
-    "/v1beta1/namespaces/{namespace_id}/schemas/{schema_name}/lineage": {
+    "/v1beta1/namespaces/{namespace_id}/schemas/{schema_id}/types/{type_name}/lineage": {
       "get": {
         "summary": "Get lineage graph for a schema",
         "operationId": "StencilService_GetLineage",
@@ -454,10 +454,18 @@
             "type": "string"
           },
           {
-            "name": "schema_name",
+            "name": "schema_id",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "description": "Schema container ID (for example, esb-log-entities)."
+          },
+          {
+            "name": "type_name",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Root proto message for lineage traversal. Accepts fully-qualified names (for example, gojek.esb.types.Location)."
           },
           {
             "name": "level",
@@ -786,7 +794,10 @@
         "namespace_id": {
           "type": "string"
         },
-        "schema_name": {
+        "schema_id": {
+          "type": "string"
+        },
+        "type_name": {
           "type": "string"
         },
         "level": {
@@ -885,7 +896,10 @@
         "namespace_id": {
           "type": "string"
         },
-        "schema_name": {
+        "schema_id": {
+          "type": "string"
+        },
+        "type_name": {
           "type": "string"
         }
       }

--- a/test_helper/seed_lineage_data.go
+++ b/test_helper/seed_lineage_data.go
@@ -1,24 +1,14 @@
 //go:build ignore
 
-// seed_lineage_data.go seeds the local Stencil server with protobuf schemas
-// that demonstrate multi-level lineage relationships.
+// seed_lineage_data.go runs an end-to-end lineage API check:
+//  1. compile descriptor from test_helper/lineage_seed.proto
+//  2. upload ONE schema container (like real usage: esb-log-entities)
+//  3. call lineage using /types/<FQN proto message>/lineage
+//  4. assert expected upstream/downstream nodes using full FQNs in the response
 //
-// Schema hierarchy (package: gotocompany.data):
+// Run:
 //
-//	Address  {}
-//	User     { address Address }        → User depends on Address
-//	Order    { user    User    }        → Order depends on User
-//	Payment  { order   Order   }        → Payment depends on Order
-//
-// Lineage for "User":
-//
-//	upstream   → Address
-//	downstream → Order → Payment
-//
-// Run: go run ./test_helper/seed_lineage_data.go
-//
-// By default this script compiles ./test_helper/lineage_seed.proto to a
-// temporary descriptor set via protoc.
+//	go run ./test_helper/seed_lineage_data.go
 package main
 
 import (
@@ -31,38 +21,55 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strings"
 )
 
 const (
 	baseURL     = "http://localhost:8080"
 	namespaceID = "gotocompany"
+	schemaID    = "esb-log-entities"
 	protoPath   = "./test_helper/lineage_seed.proto"
 )
 
-// Each schema name matches a proto message name so GetLineage can find the root FQN.
-// Nested messages (Order.Item, Payment.Receipt) are traversed automatically via the
-// same descriptor — no separate upload needed for them.
-var schemaNames = []string{"Address", "User", "Product", "Invoice", "Order", "Payment", "Item", "Receipt", "Cart", "Ledger"}
+type lineageResponse struct {
+	Direction  string        `json:"direction"`
+	Downstream []lineageNode `json:"downstream"`
+	Upstream   []lineageNode `json:"upstream"`
+	Summary    struct {
+		DownstreamCount int `json:"downstream_count"`
+		UpstreamCount   int `json:"upstream_count"`
+		TotalCount      int `json:"total_count"`
+	} `json:"summary"`
+}
+
+type lineageNode struct {
+	TypeName string `json:"type_name"`
+}
+
+type e2eCase struct {
+	name               string
+	typeName           string
+	query              string
+	wantStatus         int
+	wantDownstreamSet  []string
+	wantUpstreamSet    []string
+	wantDownstreamSize int
+	wantUpstreamSize   int
+}
 
 func main() {
-	// ── 1. Build FileDescriptorSet from proto ───────────────────────────────
+	// 1) Compile proto into descriptor bytes
 	descBytes := buildDescriptorFromProto()
 	fmt.Printf("✓ FileDescriptorSet built (%d bytes)\n", len(descBytes))
 
-	// ── 2. Create namespace ─────────────────────────────────────────────────
+	// 2) Create namespace and seed one schema container
 	createNamespace()
+	deleteSchema(schemaID)
+	uploadSchema(schemaID, descBytes)
 
-	// ── 3. Upload schema under each message name ─────────────────────────
-	for _, name := range schemaNames {
-		deleteSchema(name) // clear stale versions before re-seeding
-		uploadSchema(name, descBytes)
-	}
-
-	fmt.Println()
-	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	fmt.Println("✅  Seed complete! Use the curls below to test the lineage API:")
-	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	printCurls()
+	// 3) Execute E2E assertions
+	runE2ECases()
 }
 
 // buildDescriptorFromProto compiles the proto file using protoc and returns
@@ -164,77 +171,143 @@ func uploadSchema(schemaName string, descBytes []byte) {
 	}
 }
 
-func printCurls() {
-	type cas struct{ label, url string }
+func runE2ECases() {
+	base := fmt.Sprintf("%s/v1beta1/namespaces/%s/schemas/%s", baseURL, namespaceID, schemaID)
 
-	base := fmt.Sprintf("%s/v1beta1/namespaces/%s/schemas", baseURL, namespaceID)
-
-	cases := []cas{
+	cases := []e2eCase{
 		{
-			"Lineage for 'User' — both, level=10\n  Expected: upstream=[Address], downstream=[Order, Payment]",
-			base + "/User/lineage?level=10&direction=both",
+			name:               "container + type_name downstream location-like root",
+			typeName:           "gotocompany.events.Product",
+			query:              "direction=downstream",
+			wantStatus:         http.StatusOK,
+			wantDownstreamSet:  []string{"gotocompany.events.Order.Item", "gotocompany.events.Order", "gotocompany.events.Cart", "gotocompany.events.Payment"},
+			wantDownstreamSize: 4,
 		},
 		{
-			"Lineage for 'User' — upstream only\n  Expected: [Address]",
-			base + "/User/lineage?direction=upstream",
+			name:               "container + type_name downstream nested receipt root",
+			typeName:           "gotocompany.events.Payment.Receipt",
+			query:              "direction=downstream",
+			wantStatus:         http.StatusOK,
+			wantDownstreamSet:  []string{"gotocompany.events.Payment", "gotocompany.events.Ledger"},
+			wantDownstreamSize: 2,
 		},
 		{
-			"Lineage for 'User' — downstream only\n  Expected: [Order, Payment]",
-			base + "/User/lineage?direction=downstream",
+			name:             "container + type_name upstream cart",
+			typeName:         "gotocompany.events.Cart",
+			query:            "direction=upstream",
+			wantStatus:       http.StatusOK,
+			wantUpstreamSet:  []string{"gotocompany.events.User", "gotocompany.events.Order.Item", "gotocompany.events.Address", "gotocompany.events.Product"},
+			wantUpstreamSize: 4,
 		},
 		{
-			"Lineage for 'User' — downstream, level=1 (direct only)\n  Expected: [Order]",
-			base + "/User/lineage?direction=downstream&level=1",
+			name:       "invalid direction",
+			typeName:   "gotocompany.events.Product",
+			query:      "direction=sideways",
+			wantStatus: http.StatusBadRequest,
 		},
-		{
-			"Lineage for 'Order' — both\n  Expected: upstream=[User, Address], downstream=[Payment]",
-			base + "/Order/lineage?direction=both",
-		},
-		{
-			"Lineage for 'Address' — downstream\n  Expected: [User, Order, Payment]",
-			base + "/Address/lineage?direction=downstream",
-		},
-		{
-			// Nested message: Order.Item depends on Product;
-			// GetLineage for 'Product' will find it as the root FQN 'gotocompany.events.Order.Item.Product'? No —
-			// Product is a top-level message. Order.Item's field has TypeName='.gotocompany.events.Product'.
-			// Lineage(Product) downstream → Order.Item (nested msg inside Order)
-			"Inner use-case: Lineage for 'Product' — downstream\n  Expected: downstream=[Item] (Order.Item depends on Product)",
-			base + "/Product/lineage?direction=downstream",
-		},
-		{
-			// Nested message: Payment.Receipt depends on Invoice
-			"Inner use-case: Lineage for 'Invoice' — downstream\n  Expected: downstream=[Receipt] (Payment.Receipt depends on Invoice)",
-			base + "/Invoice/lineage?direction=downstream",
-		},
-		{
-			"Outer ref use-case: Lineage for 'Cart' — upstream\n  Expected: upstream=[Item, Product, User, Address] (Cart uses Order.Item which uses Product; also uses User)",
-			base + "/Cart/lineage?direction=upstream",
-		},
-		{
-			"Outer ref use-case: Lineage for 'Ledger' — upstream\n  Expected: upstream=[Receipt, Invoice] (Ledger uses Payment.Receipt which uses Invoice)",
-			base + "/Ledger/lineage?direction=upstream",
-		},
-		{
-			"Outer ref use-case: Lineage for 'Item' — downstream\n  Expected: downstream=[Order, Payment, Cart] (Item is used by both Order (parent) and Cart (outer ref))",
-			base + "/Item/lineage?direction=downstream",
-		},
-		{
-			"Outer ref use-case: Lineage for 'Receipt' — downstream\n  Expected: downstream=[Payment, Ledger] (Receipt is used by both Payment (parent) and Ledger (outer ref))",
-			base + "/Receipt/lineage?direction=downstream",
-		},
-		{
-			"Invalid direction — expects HTTP 400",
-			base + "/User/lineage?direction=sideways",
-		},
-	}
-
-	for _, c := range cases {
-		fmt.Printf("\n# %s\ncurl -s '%s' | python3 -m json.tool\n", c.label, c.url)
 	}
 
 	fmt.Println()
-	fmt.Println("# ── Other useful endpoints ─────────────────────────────────")
-	fmt.Printf("\n# List namespaces\ncurl -s '%s/v1beta1/namespaces' | python3 -m json.tool\n", baseURL)
-	fmt.Printf("\n# List schemas in namespace '%s'\ncurl -s '%s/v1beta1/namespaces/%s/schemas' | python3 -m json.tool\n", namespaceID, baseURL, namespaceID)
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println("🧪 Running lineage E2E cases")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+	for _, tc := range cases {
+		url := fmt.Sprintf("%s/types/%s/lineage?%s", base, tc.typeName, tc.query)
+		if err := runCase(tc, url); err != nil {
+			log.Fatalf("✗ %s: %v", tc.name, err)
+		}
+		fmt.Printf("✓ %s\n", tc.name)
+	}
+
+	fmt.Println("\n✅ All lineage E2E cases passed")
+}
+
+func runCase(tc e2eCase, url string) error {
+	resp, body, err := doGet(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != tc.wantStatus {
+		return fmt.Errorf("status mismatch: got=%d want=%d body=%s", resp.StatusCode, tc.wantStatus, string(body))
+	}
+
+	if tc.wantStatus != http.StatusOK {
+		return nil
+	}
+
+	var parsed lineageResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("decode response: %w body=%s", err, string(body))
+	}
+
+	downSet := extractNames(parsed.Downstream)
+	upSet := extractNames(parsed.Upstream)
+
+	if tc.wantDownstreamSize >= 0 && tc.wantDownstreamSize != len(downSet) && len(tc.wantDownstreamSet) > 0 {
+		return fmt.Errorf("downstream size mismatch: got=%d want=%d gotSet=%v", len(downSet), tc.wantDownstreamSize, downSet)
+	}
+	if tc.wantUpstreamSize >= 0 && tc.wantUpstreamSize != len(upSet) && len(tc.wantUpstreamSet) > 0 {
+		return fmt.Errorf("upstream size mismatch: got=%d want=%d gotSet=%v", len(upSet), tc.wantUpstreamSize, upSet)
+	}
+
+	if err := ensureContainsAll(downSet, tc.wantDownstreamSet, "downstream"); err != nil {
+		return err
+	}
+	if err := ensureContainsAll(upSet, tc.wantUpstreamSet, "upstream"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func doGet(url string) (*http.Response, []byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, nil, fmt.Errorf("http get %s: %w", url, err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, nil, fmt.Errorf("read body: %w", err)
+	}
+	return resp, body, nil
+}
+
+func extractNames(nodes []lineageNode) []string {
+	set := map[string]struct{}{}
+	for _, n := range nodes {
+		if n.TypeName == "" {
+			continue
+		}
+		set[n.TypeName] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for n := range set {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func ensureContainsAll(got []string, want []string, label string) error {
+	if len(want) == 0 {
+		return nil
+	}
+	gotMap := map[string]struct{}{}
+	for _, g := range got {
+		gotMap[g] = struct{}{}
+	}
+	missing := []string{}
+	for _, w := range want {
+		if _, ok := gotMap[w]; !ok {
+			missing = append(missing, w)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%s missing expected nodes: %s (got=%v)", label, strings.Join(missing, ", "), got)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

The lineage API previously mapped `{schema_name}` in the URL directly to both a **schema container** (stored artifact in the DB) and the **proto message name** to trace. This worked only in the early one-schema-one-message model but breaks completely for real usage where one schema artifact (e.g. `esb-log-entities`) bundles hundreds of proto messages.

This MR redesigns the lineage API endpoint so that:

1. The URL path identifies both the **schema container** (`schema_id`) and the **proto message root** (`type_name`) explicitly.
2. Response nodes return **fully-qualified proto names** (FQNs) everywhere, not short last-segment names.
3. `type_name` is a **required** path parameter — missing it returns `400`.

---

## Problem

### Before

```
GET /v1beta1/namespaces/{namespace_id}/schemas/{schema_name}/lineage
```

- `schema_name` served dual purpose: DB lookup key **and** proto message root.
- A call like `GET .../schemas/esb-log-entities/lineage` would try to find a proto message named `esb-log-entities` in the descriptor — and always return empty results for real schema containers.
- Callers had no way to specify which message inside a bundle they wanted lineage for.
- Response nodes returned short names like `Item`, `Order` — ambiguous without package context.

### After

```
GET /v1beta1/namespaces/{namespace_id}/schemas/{schema_id}/types/{type_name}/lineage
```

- `schema_id` = DB artifact key (`esb-log-entities`)
- `type_name` = fully-qualified proto message (`gojek.esb.types.Location`)
- Missing `type_name` → `400 Bad Request`
- Response nodes carry full FQNs: `gotocompany.events.Order.Item` not `Item`

---

## Changes

### API path

| | Before | After |
|---|---|---|
| Path | `/schemas/{schema_name}/lineage` | `/schemas/{schema_id}/types/{type_name}/lineage` |
| `schema_name` dual-use | ✅ (DB key + message root) | removed |
| `schema_id` | — | DB artifact key only |
| `type_name` | optional query `?type_name=` | **required** path segment |

### Response contract

| Field | Before | After |
|---|---|---|
| `root_schema.schema_name` | `"User"` | removed |
| `root_schema.schema_id` | — | `"esb-log-entities"` |
| `root_schema.type_name` | — | `"gojek.esb.types.Location"` |
| node `schema_name` | `"Item"` | removed |
| node `schema_id` | — | `"esb-log-entities"` |
| node `type_name` | `"Item"` | `"gotocompany.events.Order.Item"` |
| node `path[i]` | `["User","Item"]` | `["gotocompany.events.User","gotocompany.events.Order.Item"]` |

---

## Files changed

| File | What changed |
|---|---|
| `internal/api/api.go` | Route updated to `/schemas/{schema_id}/types/{type_name}/lineage` |
| `internal/api/schema.go` | Handler reads `schema_id` + `type_name` from path params; 400 when `type_name` empty |
| `internal/api/mocks/schema_service.go` | Updated mock signature for new `GetLineage(ctx, namespaceID, schemaID, rootType, level, direction)` |
| `internal/api/lineage_test.go` | Tests updated to use new path, new response fields; added missing-`type_name` 400 test |
| `core/schema/lineage.go` | `convertLineageNodes` now emits full FQN in `TypeName` and `Path`; `RootSchemaRef` and `LineageSchema` use `schema_id` + `type_name` |
| `core/schema/service.go` | `GetLineage` receives `schemaID` + `rootType` separately; descriptor bytes fetched by `schemaID`; lineage computed from `rootType` |
| `core/schema/lineage_test.go` | Updated to expect FQN values in assertions |
| `proto/gotocompany/apidocs.swagger.json` | Path updated; `type_name` marked `required: true` (in path); `schema_id`/`type_name` added to response definitions |
| `test_helper/seed_lineage_data.go` | Reworked into a proper E2E harness: seeds one `esb-log-entities` container, asserts FQN-based lineage per test case |

---

## Example

```bash
# Find everything that depends on gojek.esb.types.Location
# inside the esb-log-entities schema container:
curl -s 'https://<host>/v1beta1/namespaces/gojek/schemas/esb-log-entities/types/gojek.esb.types.Location/lineage?direction=downstream'
```

```json
{
  "root_schema": {
    "namespace_id": "gojek",
    "schema_id": "esb-log-entities",
    "type_name": "gojek.esb.types.Location"
  },
  "direction": "downstream",
  "downstream": [
    {
      "namespace_id": "gojek",
      "schema_id": "esb-log-entities",
      "type_name": "gojek.esb.booking.GoKilatBookingLogMessage",
      "level": 1,
      "path": [
        "gojek.esb.types.Location",
        "gojek.esb.booking.GoKilatBookingLogMessage"
      ]
    }
  ],
  "summary": {
    "downstream_count": 1,
    "upstream_count": 0,
    "total_count": 1
  }
}
```

---

## Testing

### Unit tests
```bash
go test ./internal/api ./core/schema
```

### End-to-end
```bash
# start local server first:
./stencil_bin server start -c config.local.yaml

# seed + assert:
go run ./test_helper/seed_lineage_data.go
```

E2E harness covers:
- ✅ `type_name` FQN downstream traversal (top-level message)
- ✅ `type_name` FQN downstream traversal (nested message, e.g. `Payment.Receipt`)
- ✅ `type_name` FQN upstream traversal
- ✅ `400` on invalid `direction`

---

## Breaking changes

| Breaking | Detail |
|---|---|
| URL path changed | `/schemas/{schema_name}/lineage` → `/schemas/{schema_id}/types/{type_name}/lineage` |
| `type_name` is now required | omitting it returns `400 Bad Request` |
| `schema_name` field removed | replaced by `schema_id` + `type_name` in both root and lineage nodes |
| `path` values changed | now FQNs instead of short names |

> Since the lineage API was new and had no production consumers at time of this change, this is a clean break with no migration needed.
