### PR TITLE
fix: Support Lineage Tracking for Top-Level and Nested Enums

### DIFF
--- a/core/schema/lineage.go
+++ b/core/schema/lineage.go
@@ -99,6 +99,10 @@ func findRootFQNs(fds *descriptor.FileDescriptorSet, schemaName string) []string
 		for _, msg := range fd.GetMessageType() {
 			collectFQNs(pkg, msg, allFQNs)
 		}
+
+		for _, enum := range fd.GetEnumType() {
+			allFQNs[pkg+"."+enum.GetName()] = struct{}{}
+		}
 	}
 
 	var roots []string
@@ -113,6 +117,12 @@ func findRootFQNs(fds *descriptor.FileDescriptorSet, schemaName string) []string
 func collectFQNs(prefix string, msg *descriptor.DescriptorProto, out map[string]struct{}) {
 	fqn := prefix + "." + msg.GetName()
 	out[fqn] = struct{}{}
+
+	// Collect nested enums defined inside this message
+	for _, enum := range msg.GetEnumType() {
+		out[fqn+"."+enum.GetName()] = struct{}{}
+	}
+
 	for _, nested := range msg.GetNestedType() {
 		collectFQNs(fqn, nested, out)
 	}

--- a/core/schema/lineage_test.go
+++ b/core/schema/lineage_test.go
@@ -93,6 +93,53 @@ func buildMultiLevelDescriptorSetBytes(pkg string) []byte {
 	return data
 }
 
+// buildEnumDescriptorSetBytes builds a structure where a message depends on a nested enum definition.
+// Message: DataMessage -> depends on DataTypes.Enum
+// Message: DataTypes   -> contains enum Enum { UNKNOWN = 0; }
+func buildEnumDescriptorSetBytes(pkg string) []byte {
+	// 1. Nested Enum definition: UNKNOWN = 0
+	enumValue := &descriptor.EnumValueDescriptorProto{
+		Name:   proto.String("UNKNOWN"),
+		Number: proto.Int32(0),
+	}
+	enumProto := &descriptor.EnumDescriptorProto{
+		Name:  proto.String("Enum"),
+		Value: []*descriptor.EnumValueDescriptorProto{enumValue},
+	}
+
+	// 2. Parent message structure containing the nested enum
+	typesMsg := &descriptor.DescriptorProto{
+		Name:     proto.String("DataTypes"),
+		EnumType: []*descriptor.EnumDescriptorProto{enumProto},
+	}
+
+	// 3. Primary consuming message holding a field of that enum type
+	msgField := &descriptor.FieldDescriptorProto{
+		Name:     proto.String("action_type"),
+		Number:   proto.Int32(4),
+		Type:     descriptor.FieldDescriptorProto_TYPE_ENUM.Enum(),
+		TypeName: proto.String("." + pkg + ".DataTypes.Enum"),
+	}
+	dataMsg := &descriptor.DescriptorProto{
+		Name:  proto.String("DataMessage"),
+		Field: []*descriptor.FieldDescriptorProto{msgField},
+	}
+
+	// 4. File layout setup
+	file := &descriptor.FileDescriptorProto{
+		Name:        proto.String("generic_data.proto"),
+		Package:     proto.String(pkg),
+		MessageType: []*descriptor.DescriptorProto{dataMsg, typesMsg},
+	}
+
+	fds := &descriptor.FileDescriptorSet{
+		File: []*descriptor.FileDescriptorProto{file},
+	}
+
+	data, _ := proto.Marshal(fds)
+	return data
+}
+
 // ---------------------------------------------------------------------------
 // Service.GetLineage tests
 // ---------------------------------------------------------------------------
@@ -279,6 +326,32 @@ func TestGetLineage(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid direction")
+	})
+
+	t.Run("should return downstream lineage when tracing starting from an enum", func(t *testing.T) {
+		svc, _, _, schemaRepo, newrelic, _, _, _ := getSvc()
+		pkg := "mypackage"
+		data := buildEnumDescriptorSetBytes(pkg)
+
+		// Mocking database retrieval with neutral variables matching standard test layout
+		schemaRepo.On("GetLatestVersion", mock.Anything, "ns1", "generic-schema").Return(int32(1), nil)
+		schemaRepo.On("GetMetadata", mock.Anything, "ns1", "generic-schema").Return(&schema.Metadata{Format: "protobuf"}, nil)
+		schemaRepo.On("Get", mock.Anything, "ns1", "generic-schema", int32(1)).Return(data, nil)
+		newrelic.On("StartGenericSegment", mock.Anything, mock.Anything).Return(func() {})
+
+		// Call lineage starting directly from the Enum type name suffix
+		resp, err := svc.GetLineage(ctx, "ns1", "generic-schema", "DataTypes.Enum", 5, schema.LineageDirectionDownstream)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, schema.LineageDirectionDownstream, resp.Direction)
+		assert.Equal(t, "DataTypes.Enum", resp.RootSchema.TypeName)
+
+		// Verify that downstream lineage successfully identified the consuming Message
+		assert.Equal(t, 1, resp.Summary.DownstreamCount)
+		assert.Equal(t, "mypackage.DataMessage", resp.Downstream[0].TypeName)
+		assert.Equal(t, 1, resp.Downstream[0].Level)
+		assert.Equal(t, []string{"mypackage.DataTypes.Enum", "mypackage.DataMessage"}, resp.Downstream[0].Path)
 	})
 }
 

--- a/test_helper/lineage_seed.proto
+++ b/test_helper/lineage_seed.proto
@@ -10,16 +10,20 @@ package gotocompany.events;
 //                              │               └──────────────────── Cart (outer ref to Order.Item)
 //                              └──────────────────────────────────── Ledger (outer ref to Payment.Receipt)
 //
-// Upstream  (what a message depends on)
-// Downstream (what depends on that message)
+//  Enum use-cases:
+//    Status (top-level enum) ─────────────────────────────────────── Order (field: status)
+//    DataTypes (message)
+//      └── DataTypes.Enum (nested enum)
+//                         └────────────────────────────────────────  DataMessage (field: action_type)
 //
-// Examples:
-//   Lineage(User)        upstream=[Address]              downstream=[Order, Payment, Cart, Ledger, ...]
-//   Lineage(Order)       upstream=[User, Address]        downstream=[Payment, Cart, Ledger, ...]
-//   Lineage(Product)     upstream=[]                     downstream=[Item, Order, Cart, ...]
-//   Lineage(Invoice)     upstream=[]                     downstream=[Receipt, Payment, Ledger]
-//   Lineage(Order.Item)  upstream=[Product]              downstream=[Order (parent), Cart (outer ref)]
-//   Lineage(Payment.Receipt) upstream=[Invoice]          downstream=[Payment (parent), Ledger (outer ref)]
+//  DataMessage depends on: User, DataTypes.Enum (→ DataTypes), Status
+//
+// Upstream / Downstream examples (updated):
+//   Lineage(User)            upstream=[Address]              downstream=[Order, Payment, Cart, Ledger, DataMessage, ...]
+//   Lineage(DataTypes)       upstream=[]                     downstream=[DataTypes.Enum, DataMessage]
+//   Lineage(DataTypes.Enum)  upstream=[DataTypes (parent)]   downstream=[DataMessage]
+//   Lineage(Status)          upstream=[]                     downstream=[Order, DataMessage]
+//   Lineage(DataMessage)     upstream=[User, Address, DataTypes.Enum, DataTypes, Status]
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Leaf entity — no dependencies
@@ -49,11 +53,21 @@ message Invoice {
   double amount = 2;
 }
 
-// Depends on: User
+// Top-level enum use-case: a standalone enum referenced by multiple messages.
+// Demonstrates that a top-level enum surfaces as a dependency in lineage,
+// just like a leaf message would.
+enum Status {
+  STATUS_UNKNOWN  = 0;
+  STATUS_ACTIVE   = 1;
+  STATUS_INACTIVE = 2;
+}
+
+// Depends on: User, Status
 // Contains nested message: Order.Item (depends on Product)
 message Order {
-  string id   = 1;
-  User   user = 2;
+  string id     = 1;
+  User   user   = 2;
+  Status status = 4; // top-level enum field
 
   // Inner use-case: nested message that introduces its own dependency (Product)
   message Item {
@@ -72,8 +86,8 @@ message Payment {
 
   // Inner use-case: nested message that introduces its own dependency (Invoice)
   message Receipt {
-    Invoice invoice    = 1;
-    string  issued_at  = 2;
+    Invoice invoice   = 1;
+    string  issued_at = 2;
   }
 
   Receipt receipt = 3;
@@ -82,9 +96,9 @@ message Payment {
 // Outer use-case: references Order.Item directly (not through Order)
 // Shows that a nested type can be used as a first-class dependency outside its parent.
 message Cart {
-  string     id       = 1;
-  User       user     = 2;
-  Order.Item item     = 3; // direct reference to the nested type
+  string     id   = 1;
+  User       user = 2;
+  Order.Item item = 3; // direct reference to the nested type
 }
 
 // Outer use-case: references Payment.Receipt directly (not through Payment)
@@ -94,3 +108,23 @@ message Ledger {
   Payment.Receipt receipt = 2; // direct reference to the nested type
 }
 
+// Nested enum use-case: a message whose sole purpose is to namespace an enum.
+// DataTypes.Enum is referenced externally by DataMessage, demonstrating that
+// a nested enum type creates a lineage edge just like a nested message type does.
+message DataTypes {
+  enum Enum {
+    UNKNOWN = 0;
+    SET     = 1;
+    UNSET   = 2;
+  }
+}
+
+// Depends on: User, DataTypes.Enum (nested enum), Status (top-level enum)
+// Demonstrates that enum fields (both top-level and nested) are tracked in lineage.
+message DataMessage {
+  string          id              = 1;
+  User            user            = 2;
+  DataTypes.Enum  action_type     = 3; // nested enum reference
+  Status          status          = 4; // top-level enum reference
+  repeated string item_sequence   = 5;
+}

--- a/test_helper/seed_lineage_data.go
+++ b/test_helper/seed_lineage_data.go
@@ -205,6 +205,54 @@ func runE2ECases() {
 			query:      "direction=sideways",
 			wantStatus: http.StatusBadRequest,
 		},
+
+		// ── enum use-cases ────────────────────────────────────────────────────────
+
+		// DataMessage depends on User (→ Address), DataTypes.Enum (→ DataTypes), and Status.
+		{
+			name:       "upstream of DataMessage includes user chain + enum deps",
+			typeName:   "gotocompany.events.DataMessage",
+			query:      "direction=upstream",
+			wantStatus: http.StatusOK,
+			wantUpstreamSet: []string{
+				"gotocompany.events.User",
+				"gotocompany.events.Address",
+				"gotocompany.events.DataTypes",
+				"gotocompany.events.DataTypes.Enum",
+				"gotocompany.events.Status",
+			},
+			wantUpstreamSize: 5,
+		},
+
+		// DataTypes.Enum (nested enum) is referenced by DataMessage.
+		{
+			name:               "downstream of nested enum DataTypes.Enum",
+			typeName:           "gotocompany.events.DataTypes.Enum",
+			query:              "direction=downstream",
+			wantStatus:         http.StatusOK,
+			wantDownstreamSet:  []string{"gotocompany.events.DataMessage"},
+			wantDownstreamSize: 1,
+		},
+
+		// DataTypes (the wrapper message) transitively reaches DataMessage through DataTypes.Enum.
+		{
+			name:               "downstream of DataTypes wrapper message",
+			typeName:           "gotocompany.events.DataTypes",
+			query:              "direction=downstream",
+			wantStatus:         http.StatusOK,
+			wantDownstreamSet:  []string{"gotocompany.events.DataTypes.Enum", "gotocompany.events.DataMessage"},
+			wantDownstreamSize: 2,
+		},
+
+		// Status (top-level enum) is referenced by both Order and DataMessage.
+		{
+			name:               "downstream of top-level enum Status",
+			typeName:           "gotocompany.events.Status",
+			query:              "direction=downstream",
+			wantStatus:         http.StatusOK,
+			wantDownstreamSet:  []string{"gotocompany.events.Order", "gotocompany.events.DataMessage"},
+			wantDownstreamSize: 2,
+		},
 	}
 
 	fmt.Println()


### PR DESCRIPTION
**Overview**
This PR fixes a bug in the Stencil Lineage API where requesting lineage for an Enum FQN (e.g., `gotocompany.events.DataTypes.Enum`) incorrectly returned an empty result (`downstream_count: 0`). 

The root cause was a blind spot in the AST root lookup engine. The `findRootFQNs` and `collectFQNs` functions were exclusively iterating over Message types (`fd.GetMessageType()`), meaning Enum definitions were never registered as valid vertices in the lineage graph. Consequently, the traversal skipped them entirely.

**Key Changes**

* **Top-Level Enum Support:** Updated `findRootFQNs` to iterate over and index `fd.GetEnumType()`, ensuring file-level enums are registered in the graph lookup map.
* **Nested Enum Support:** Updated the recursive `collectFQNs` function to iterate over and index `msg.GetEnumType()`, allowing enums nested inside parent messages to be accurately targeted.
* **Test Coverage:** Added a dedicated descriptor builder (`buildEnumDescriptorSetBytes`) and subtest to verify that tracing downstream lineage starting *directly* from an Enum successfully identifies the parent messages and schemas that consume it.

**Impact**
This fix unlocks accurate downstream impact analysis for Enum modifications.